### PR TITLE
Reformat

### DIFF
--- a/lib/issues.js
+++ b/lib/issues.js
@@ -35,7 +35,7 @@ const list = (action, issues) => {
 			section += `\n_${repo}_:\n`;
 
 			const repoSpecificIssues = categorisedIssues.filter(issue => issue.repository === repo);
-			repoSpecificIssues.forEach(issue => section += `— <${issue.url}| ${issue.title}>\n`);
+			repoSpecificIssues.forEach(issue => section += `\t— <${issue.url}| ${issue.title}>\n`);
 		});
 
 		return section + '\n';

--- a/test/unit/lib/issues.test.js
+++ b/test/unit/lib/issues.test.js
@@ -67,7 +67,7 @@ describe('list', () => {
 			}
 		];
 
-		const mockList = '*Opened*\n\n_test_:\n— <#| issue 1>\n— <#| issue 2>\n\n';
+		const mockList = '*Opened*\n\n_test_:\n\t— <#| issue 1>\n\t— <#| issue 2>\n\n';
 
 		const openedIssues = list('opened', mockIssues);
 		proclaim.deepStrictEqual(openedIssues, mockList);

--- a/test/unit/lib/slack.test.js
+++ b/test/unit/lib/slack.test.js
@@ -29,7 +29,7 @@ describe('slack', () => {
 
 	const mockPayload = {
 		mrkdwn: true,
-		text: '*Issue activity since Friday morning*\n*Closed*\n\n_test_:\n— <#| issue 3>\n\n*Opened*\n\n_test_:\n— <#| issue 1>\n— <#| issue 2>\n\n'
+		text: '*Issue activity since Friday morning*\n*Closed*\n\n_test_:\n\t— <#| issue 3>\n\n*Opened*\n\n_test_:\n\t— <#| issue 1>\n\t— <#| issue 2>\n\n'
 	};
 
 	afterEach(() => {


### PR DESCRIPTION
A small payload reformatting, so that chunkier issue messages are a bit easier to read:

_before_

<img width="295" alt="screenshot 2019-02-06 at 08 51 23" src="https://user-images.githubusercontent.com/16777943/52330109-6bda4c80-29ec-11e9-8ce4-f6efb532af95.png">

_after:_

<img width="259" alt="screenshot 2019-02-06 at 08 51 12" src="https://user-images.githubusercontent.com/16777943/52330108-6b41b600-29ec-11e9-938f-79fc5ae3bbb9.png">
